### PR TITLE
docs: Enhance project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,17 @@ just deploy
 
 ```
 apps/
-├── api/  # Core API worker
-└── web/  # Web app worker
+├── api/  # Core API worker for handling backend logic and data processing.
+└── web/  # Web app worker for the user interface and client-side interactions.
 
 packages/
-├── hono-helpers/     # Shared Hono middleware
-├── typescript-config/ # Shared TypeScript settings
-├── tools/             # Development utilities
-├── app-client/        # Nodejs client
+├── hono-helpers/     # Shared Hono middleware for common API functionalities.
+├── typescript-config/ # Shared TypeScript settings to ensure code consistency.
+├── tools/             # Development utilities for building and maintaining the project.
+├── app-client/        # Node.js client for interacting with the API.
 ```
+
+For more detailed documentation, please refer to the [docs](./apps/docs/docs/README.md) section.
 
 ## 🧪 Testing
 

--- a/apps/docs/docs/.vuepress/config.js
+++ b/apps/docs/docs/.vuepress/config.js
@@ -12,6 +12,21 @@ export default defineUserConfig({
 		logo: 'https://vuejs.press/images/hero.png',
 
 		navbar: ['/', '/get-started', '/development/'],
+
+		sidebar: [
+			{
+				text: 'Introduction',
+				children: ['/get-started.md'],
+			},
+			{
+				text: 'Development',
+				children: ['/development/'], // VuePress resolves this to /development/README.md
+			},
+			{
+				text: 'Applications',
+				children: ['/apps/api.md'],
+			},
+		],
 	}),
 
 	bundler: viteBundler(),

--- a/apps/docs/docs/README.md
+++ b/apps/docs/docs/README.md
@@ -1,33 +1,28 @@
 ---
 home: true
 title: Home
-heroImage: https://vuejs.press/images/hero.png
+heroText: Smart Medical Records (SMEDREC)
+tagline: Welcome to the documentation for Smart Medical Records (SMEDREC), a modern, open-source medical records system.
 actions:
   - text: Get Started
     link: /get-started.html
     type: primary
 
-  - text: Introduction
-    link: https://vuejs.press/guide/introduction.html
+  - text: Project Overview
+    link: /project-overview.md
     type: secondary
 
 features:
-  - title: Simplicity First
-    details: Minimal setup with markdown-centered project structure helps you focus on writing.
-  - title: Vue-Powered
-    details: Enjoy the dev experience of Vue, use Vue components in markdown, and develop custom themes with Vue.
-  - title: Performant
-    details: VuePress generates pre-rendered static HTML for each page, and runs as an SPA once a page is loaded.
-  - title: Themes
-    details: Providing a default theme out of the box. You can also choose a community theme or create your own one.
-  - title: Plugins
-    details: Flexible plugin API, allowing plugins to provide lots of plug-and-play features for your site.
-  - title: Bundlers
-    details: Default bundler is Vite, while Webpack is also supported. Choose the one you like!
+  - title: Comprehensive Patient Management
+    details: Store and organize medical records, track treatments, forms, and conclusions effectively.
+  - title: Cloud-Native Architecture
+    details: Built with Cloudflare Workers for a scalable, secure, and edge-native solution.
+  - title: Developer Friendly
+    details: Monorepo structure using Turborepo & pnpm for efficient development, and type-safe code with TypeScript.
+  - title: Customizable Data Collection
+    details: Design your own questionnaires and forms for next-generation analytics and tailored client information.
+  - title: Built-in Security
+    details: Features transit encryption, secure isolated networks, and built-in firewalls for data protection.
 
 footer: MIT Licensed | Copyright © 2025-present José Cordeiro
 ---
-
-This is the content of home page. Check [Home Page Docs][default-theme-home] for more details.
-
-[default-theme-home]: https://vuejs.press/reference/default-theme/frontmatter.html#home-page

--- a/apps/docs/docs/apps/api.md
+++ b/apps/docs/docs/apps/api.md
@@ -1,0 +1,49 @@
+# API Application (`apps/api`)
+
+The `apps/api` application is the backbone of the SMEDREC system, providing the core backend logic, data storage, and service integrations. It's built using Hono, running on Cloudflare Workers, and interacts with a database via Drizzle ORM.
+
+## Overview
+
+- **Purpose**: Serves as the central API for all client applications (web, mobile, etc.) and external integrations.
+- **Technology Stack**:
+    - Runtime: Cloudflare Workers
+    - Framework: Hono
+    - ORM: Drizzle ORM
+    - Language: TypeScript
+
+## Key Features
+
+- Secure data handling for patient records, treatments, and forms.
+- User authentication and authorization.
+- Business logic for case management.
+- Integration points for other services (e.g., FHIR, external analytics).
+
+## Architecture
+
+(To be detailed: High-level architecture, request flow, key components like middleware, routing structure, etc.)
+
+## Major Endpoints
+
+(To be detailed: List key API endpoints, their purpose, request/response formats. For example:)
+- `POST /auth/login` - User authentication.
+- `GET /patients` - Retrieve a list of patients.
+- `POST /patients` - Create a new patient.
+- `GET /patients/{id}` - Retrieve a specific patient.
+- `GET /cases` - Retrieve case studies.
+- ... and so on.
+
+## Authentication & Authorization
+
+(To be detailed: Explanation of how authentication works, token types (e.g., JWT), and how authorization/permissions are handled, possibly referencing policy files if they are used e.g. Cerbos policies mentioned in file listing).
+
+## Error Handling
+
+(To be detailed: Common error codes and responses.)
+
+## Local Development
+
+The API can be run locally using the `just dev` command, which typically starts it on `http://localhost:8787`. Refer to the [Get Started](../get-started.md) guide for more details on running the project.
+
+## Contributing
+
+If you are contributing to the API, ensure your changes are well-tested and documented.

--- a/apps/docs/docs/get-started.md
+++ b/apps/docs/docs/get-started.md
@@ -1,46 +1,65 @@
 # Get Started
 
-This is a normal page, which contains VuePress basics.
+This guide will walk you through setting up your development environment for SMEDREC and running the project locally.
 
-## Pages
+## Prerequisites
 
-You can add markdown files in your vuepress directory, every markdown file will be converted to a page in your site.
+Before you begin, ensure you have the following installed:
+- [Node.js](https://nodejs.org/) (LTS version recommended)
+- [pnpm](https://pnpm.io/installation)
+- [Just](https://github.com/casey/just#installation) (a command runner)
 
-See [routing][] for more details.
+## Installation
 
-## Content
+1.  **Clone the repository:**
+    ```bash
+    git clone https://github.com/YOUR_USERNAME/YOUR_REPOSITORY.git # Replace with actual repo URL
+    cd YOUR_REPOSITORY_NAME
+    ```
+    *Note: If you are a contributor, fork the repository first and clone your fork.*
 
-Every markdown file [will be rendered to HTML, then converted to a Vue SFC][content].
+2.  **Install dependencies:**
+    The project uses `pnpm` for package management and `Just` for running scripts. Install all dependencies using the following command:
+    ```bash
+    just install
+    ```
+    This command will install dependencies for all apps and packages in the monorepo.
 
-VuePress support basic markdown syntax and [some extensions][synatex-extensions], you can also [use Vue features][vue-feature] in it.
+## Running the Development Servers
 
-## Configuration
+To start the development servers for all applications (e.g., API, web frontend), run:
+```bash
+just dev
+```
+This will typically start the API server and the web application, allowing you to interact with SMEDREC in your local environment. Check your terminal output for the specific ports they are running on (e.g., `http://localhost:3000` for the web app, `http://localhost:8787` for the API).
 
-VuePress use a `.vuepress/config.js`(or .ts) file as [site configuration][config], you can use it to config your site.
+## Building for Production
 
-For [client side configuration][client-config], you can create `.vuepress/client.js`(or .ts).
+To build all applications for production, use:
+```bash
+just build
+```
 
-Meanwhile, you can also add configuration per page with [frontmatter][].
+## Running Tests
 
-## Layouts and customization
+To run all tests across the project, use:
+```bash
+just test
+```
+You can also run tests for a specific application or package. For example, to test the API:
+```bash
+pnpm turbo -F api test
+```
 
-Here are common configuration controlling layout of `@vuepress/theme-default`:
+## Deployment
 
-- [navbar][]
-- [sidebar][]
+To deploy the applications (typically to Cloudflare Workers), use:
+```bash
+just deploy
+```
+Ensure you have your Cloudflare account and Wrangler configured correctly. Refer to the Cloudflare Wrangler documentation for more details if needed.
 
-Check [default theme docs][default-theme] for full reference.
+## Next Steps
 
-You can [add extra style][style] with `.vuepress/styles/index.scss` file.
-
-[routing]: https://vuejs.press/guide/page.html#routing
-[content]: https://vuejs.press/guide/page.html#content
-[synatex-extensions]: https://vuejs.press/guide/markdown.html#syntax-extensions
-[vue-feature]: https://vuejs.press/guide/markdown.html#using-vue-in-markdown
-[config]: https://vuejs.press/guide/configuration.html#client-config-file
-[client-config]: https://vuejs.press/guide/configuration.html#client-config-file
-[frontmatter]: https://vuejs.press/guide/page.html#frontmatter
-[navbar]: https://vuejs.press/reference/default-theme/config.html#navbar
-[sidebar]: https://vuejs.press/reference/default-theme/config.html#sidebar
-[default-theme]: https://vuejs.press/reference/default-theme/
-[style]: https://vuejs.press/reference/default-theme/styles.html#style-file
+- Explore the [Project Structure](./project-structure.md)
+- Learn about our [Development Workflow](./development/workflow.md)


### PR DESCRIPTION
This commit introduces several improvements to the project documentation:

- I updated the main README.md with a more detailed project structure overview and a direct link to the `apps/docs` site.
- I revamped the `apps/docs/docs/README.md` (VuePress homepage) with project-specific branding, hero content, and feature descriptions.
- I significantly enhanced `apps/docs/docs/get-started.md` to provide a comprehensive guide for prerequisites, installation, running the development environment, building, testing, and deployment.
- I added a new documentation page for the `apps/api` application at `apps/docs/docs/apps/api.md`, outlining its purpose, tech stack, key features, and placeholders for detailed API specifics.
- I updated the VuePress sidebar configuration in `apps/docs/docs/.vuepress/config.js` to include the new `apps/api.md` page under an "Applications" section, and also structured existing pages like "Get Started" and "Development" into logical groups.